### PR TITLE
SC-2121

### DIFF
--- a/src/mpm/canmodel.py
+++ b/src/mpm/canmodel.py
@@ -167,7 +167,7 @@ class Signal(epyqlib.treenode.TreeNode):
         if self.signed:
             bits -= 1
 
-        r = 2**bits
+        r = 2 ** bits
 
         if self.signed:
             minimum = -r

--- a/src/mpm/mainwindow.py
+++ b/src/mpm/mainwindow.py
@@ -690,9 +690,13 @@ class Window:
                 if len(duplicates) == 0:
                     message = "No duplicate IDs found."
                 else:
-                    duplicate_list = ["{}: {}".format(d.identifier, d.name) for d in duplicates]
+                    duplicate_list = [
+                        "{}: {}".format(d.identifier, d.name) for d in duplicates
+                    ]
                     duplicate_str = "\n".join(duplicate_list)
-                    message = "Following duplicate IDs were found:\n\n{}".format(duplicate_str)
+                    message = "Following duplicate IDs were found:\n\n{}".format(
+                        duplicate_str
+                    )
 
                 QtWidgets.QMessageBox.information(
                     self.main_window,

--- a/src/mpm/mainwindow.py
+++ b/src/mpm/mainwindow.py
@@ -644,6 +644,12 @@ class Window:
         update = menu.addAction("Update")
         update.setEnabled(hasattr(node, "update"))
 
+        optimize = menu.addAction("Optimize multiplexers")
+        optimize.setVisible(isinstance(node, mpm.canmodel.MultiplexedMessage))
+
+        check_duplicates = menu.addAction("Check for duplicate IDs")
+        check_duplicates.setVisible(isinstance(node, mpm.canmodel.MultiplexedMessage))
+
         menu.addSeparator()
 
         delete = menu.addAction("&Delete")
@@ -677,6 +683,23 @@ class Window:
                 node.tree_parent.remove_child(child=node)
             elif action is update:
                 node.update()
+            elif action is optimize:
+                node.optimize_multiplexer_ids()
+            elif action is check_duplicates:
+                duplicates = node.check_duplicate_ids()
+                if len(duplicates) == 0:
+                    message = "No duplicate IDs found."
+                else:
+                    duplicate_list = ["{}: {}".format(d.identifier, d.name) for d in duplicates]
+                    duplicate_str = "\n".join(duplicate_list)
+                    message = "Following duplicate IDs were found:\n\n{}".format(duplicate_str)
+
+                QtWidgets.QMessageBox.information(
+                    self.main_window,
+                    "Results",
+                    message,
+                )
+
             elif action is expand_tree:
                 epyqlib.utils.qt.set_expanded_tree(
                     view=view,


### PR DESCRIPTION
## Jira Story
[SC-2121](https://epcpower.atlassian.net/browse/SC-2121)

## About
Add commands to fill gaps between multiplexer IDs automatically and check for duplicate IDs in CAN messages.
The features can be accessed by right-clicking a MultiplexedMessage object in the CAN tree view.

![kuva](https://github.com/epcpower/m-pm/assets/83573646/6e807dc1-e22d-429b-987d-316920c8c8d1)

## Associated Pull Requests

* [ ] _
* [ ] _

## Reproduction Steps

## Validation


[SC-2121]: https://epcpower.atlassian.net/browse/SC-2121?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ