### PR TITLE
Feature/sc 2121/bcu params to tcu interface 3

### DIFF
--- a/src/mpm/cli/exportsym.py
+++ b/src/mpm/cli/exportsym.py
@@ -19,6 +19,7 @@ def relative_path(target, reference):
 
 @click.command()
 @click.option("--project", "project_file", type=click.File(), required=True)
+@click.option("--bcu-project", "bcu_project_file", type=click.File(), required=False)
 @click.option("--sym", "sym_file", type=click.File("w"), required=True)
 @click.option(
     "--hierarchy",
@@ -28,6 +29,7 @@ def relative_path(target, reference):
 )
 def cli(project_file, sym_file, hierarchy_file):
     project = mpm.project.load(project_file)
+    bcu_project = mpm.project.load(bcu_project_file)
 
     (access_levels,) = project.models.parameters.root.nodes_by_filter(
         filter=(lambda node: isinstance(node, epyqlib.pm.parametermodel.AccessLevels)),

--- a/src/mpm/importexport.py
+++ b/src/mpm/importexport.py
@@ -194,7 +194,9 @@ def can_hierarchy_export(
     if bcu_project:
 
         # Before merging BCU and TCU models, export the TCU sym file without BCU parameters
-        no_bcu_symfile = paths.can.with_name(paths.can.stem + "_NO_BCU" + paths.can.suffix)
+        no_bcu_symfile = paths.can.with_name(
+            paths.can.stem + "_NO_BCU" + paths.can.suffix
+        )
         mpm.cantosym.export(
             path=no_bcu_symfile,
             can_model=project.models.can,

--- a/src/mpm/importexport.py
+++ b/src/mpm/importexport.py
@@ -192,6 +192,16 @@ def can_hierarchy_export(
 
     # If BCU project is included, add its contents to CAN and Parameter models
     if bcu_project:
+
+        # Before merging BCU and TCU models, export the TCU sym file without BCU parameters
+        no_bcu_symfile = paths.can.with_name(paths.can.stem + "_NO_BCU" + paths.can.suffix)
+        mpm.cantosym.export(
+            path=no_bcu_symfile,
+            can_model=project.models.can,
+            parameters_model=project.models.parameters,
+        )
+
+        # Merge BCU parameters and CAN definitions into TCU models
         merge_parameter_models(
             project.models.parameters.root, bcu_project.models.parameters.root
         )

--- a/src/mpm/importexport.py
+++ b/src/mpm/importexport.py
@@ -9,6 +9,7 @@ import graham
 
 import mpm.cantosym
 import mpm.cantoxlsx
+import mpm.canmodel
 import mpm.importexportdialog
 import mpm.parameterstobitfieldsc
 import mpm.parameterstohierarchy
@@ -30,6 +31,7 @@ import mpm.symtoproject
 import mpm.anomaliestoc
 import mpm.anomaliestoxlsx
 import epyqlib.attrsmodel
+import epyqlib.pm.parametermodel
 
 
 def full_import(paths):
@@ -116,14 +118,87 @@ def full_import(paths):
     return project
 
 
-def full_export(
+def merge_can_models(dest, src):
+    """
+    Merges CAN root node src into dest.
+
+    Args:
+        dest: Destination CAN root node
+        src: Source CAN root node
+    Returns:
+        None
+    """
+    for src_child in src.children:
+        if src_child.name == "ParameterQuery":
+
+            # Find destination ParameterQuery
+            dest_param_query = None
+            for c in dest.children:
+                if c.name == "ParameterQuery":
+                    dest_param_query = c
+                    break
+
+            # Append Multiplexers from source under it
+            # Shift identifiers and add "BCU_" prefix to avoid conflicts
+            for c in src_child.children:
+                if isinstance(c, mpm.canmodel.Multiplexer):
+                    c.name = "BCU_" + c.name
+                    c.identifier += 1500
+                    dest_param_query.append_child(c)
+
+        # Add everything else except ParameterResponse with a "BCU_" prefix
+        # One ParameterResponse definition is enough as it is a clone of ParameterQuery
+        elif src_child.name != "ParameterResponse":
+            dest.append_child(src_child)
+            dest.children[-1].name = "BCU_" + dest.children[-1].name
+
+
+def merge_parameter_models(dest, src):
+    """
+    Merges parameter root node src into dest.
+
+    Args:
+        dest: Destination parameter root node
+        src: Source parameter root node
+    Returns:
+        None
+    """
+    for src_child in src.children:
+        if src_child.name == "Parameters" or src_child.name == "Enumerations":
+            for dest_child in dest.children:
+                # BCU parameters are added under the Parameter group as a subgroup
+                if dest_child.name == src_child.name == "Parameters":
+                    dest_child.append_child(src_child)
+                    dest_child.children[-1].name = "BCU_" + dest_child.children[-1].name
+                # Enumerations are merged under the same group
+                if dest_child.name == src_child.name == "Enumerations":
+                    for enum in src_child.children:
+                        dest_child.append_child(enum)
+                    break
+        else:
+            # Others are added under Root as subgroups
+            dest.append_child(src_child)
+            dest.children[-1].name = "BCU_" + dest.children[-1].name
+
+
+def can_hierarchy_export(
     project,
+    bcu_project,
     paths,
-    target_directory,
-    first_time=False,
-    skip_output=False,
-    include_uuid_in_item=False,
-):
+) -> None:
+    """
+    Exports parameter hierarchy and CAN symbol files
+    """
+
+    # If BCU project is included, add its contents to CAN and Parameter models
+    if bcu_project:
+        merge_parameter_models(
+            project.models.parameters.root, bcu_project.models.parameters.root
+        )
+        merge_can_models(project.models.can.root, bcu_project.models.can.root)
+
+    # Use extended models with BCU parameter info when exporing sym and
+    # parameter hierarchies
     mpm.cantosym.export(
         path=paths.can,
         can_model=project.models.can,
@@ -135,6 +210,17 @@ def full_export(
         can_model=project.models.can,
         parameters_model=project.models.parameters,
     )
+
+
+def interface_code_export(
+    project,
+    paths,
+    skip_output=False,
+    include_uuid_in_item=False,
+):
+    """
+    Exports interface code
+    """
 
     mpm.parameterstointerface.export(
         c_path=paths.interface_c,
@@ -167,6 +253,19 @@ def full_export(
         parameters_model=project.models.parameters,
         skip_output=False,
     )
+
+
+def full_export(
+    project,
+    bcu_project,
+    paths,
+    target_directory,
+    first_time=False,
+    skip_output=False,
+    include_uuid_in_item=False,
+):
+    can_hierarchy_export(project, bcu_project, paths)
+    interface_code_export(project, paths, skip_output, include_uuid_in_item)
 
 
 def modification_time_or(path, alternative):

--- a/src/mpm/parameterstointerface.py
+++ b/src/mpm/parameterstointerface.py
@@ -183,8 +183,10 @@ class Root:
             uuids = [
                 # CCP Response
                 uuid.UUID("39315d58-1ddb-48b9-960c-96e724c89da1"),
+                uuid.UUID("aa6c07ba-fa28-4a31-9b7c-91848b0e38e7"),
                 # CCP
                 uuid.UUID("983bdc5d-8d4e-4107-a0a0-983f0ab101ce"),
+                uuid.UUID("5be0a2f4-8f32-4844-a285-ca94198936f1"),
             ]
             return not any(ancestor.uuid in uuids for ancestor in node.ancestors())
 

--- a/src/mpm/parameterstointerface.py
+++ b/src/mpm/parameterstointerface.py
@@ -183,10 +183,10 @@ class Root:
             uuids = [
                 # CCP Response
                 uuid.UUID("39315d58-1ddb-48b9-960c-96e724c89da1"),
-                uuid.UUID("aa6c07ba-fa28-4a31-9b7c-91848b0e38e7"),
+                uuid.UUID("d35c7e1a-605c-42ab-a5f2-43a1eb6a1d04"),
                 # CCP
                 uuid.UUID("983bdc5d-8d4e-4107-a0a0-983f0ab101ce"),
-                uuid.UUID("5be0a2f4-8f32-4844-a285-ca94198936f1"),
+                uuid.UUID("f63f19bf-9c0f-47dd-9f4b-7877b31796f0"),
             ]
             return not any(ancestor.uuid in uuids for ancestor in node.ancestors())
 


### PR DESCRIPTION
## Jira Story
[SC-2121](https://epcpower.atlassian.net/browse/SC-2121)

## About
Adds possibility to merge BCU parameters under TCU parameter tree when generating parameter interface.

- Adds new option "bcu_project" to pm export function, which defines a path to the BCU pm project file
- If the BCU project is given, the parameter and CAN definitions found under the project are merged into the TCU project during interface generation
- Interface file and code generations are split into separate functions to have different inputs for interface code and interface file generations:
  - Interface code is only generated for TCU parameters
  - Parameter hierarchy is generated for merged TCU + BCU parameters
  - CAN symbol files are generated for both TCU parameters and merged TCU + BCU parameters. This is because a part of the interface code generation takes the CAN symbol file as an input, and it occurs outside pm (m-tcu\src\mtcu\generateiterface.py)
- BCU parameters have their CAN multiplexer ID's shifted by 1500 to avoid conflicts with TCU parameters
- Prefix "BCU_" is added to BCU CAN Multiplexer names to avoid conflicts with TCU parameters

## Associated Pull Requests

* [ ] _https://github.com/epcpower/m-tcu/pull/74
* [ ] _

## Reproduction Steps

## Validation
It has been verified that BCU parameters appear in EPyQ interface and TCU control board is able to see parameter requests sent from EPyQ.

![kuva](https://github.com/user-attachments/assets/0d66dd45-885a-46eb-a8a6-433fb9f4ca29)


[SC-2121]: https://epcpower.atlassian.net/browse/SC-2121?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ