### PR TITLE
feat(SC-2603): Only add parameters with Service tech access level to …

### DIFF
--- a/src/mpm/mainwindow.py
+++ b/src/mpm/mainwindow.py
@@ -9,6 +9,7 @@ import pathlib
 import attr
 import pycparser.c_ast
 import pycparser.c_generator
+from PyQt5.Qt import QApplication
 from PyQt5 import QtCore, QtGui, QtWidgets
 
 import epyqlib.attrsmodel
@@ -647,6 +648,12 @@ class Window:
         optimize = menu.addAction("Optimize multiplexers")
         optimize.setVisible(isinstance(node, mpm.canmodel.MultiplexedMessage))
 
+        copyuuid = menu.addAction("Copy UUID")
+        copyuuid.setVisible(hasattr(node, "uuid"))
+
+        copyname = menu.addAction("Copy name")
+        copyname.setVisible(hasattr(node, "name"))
+
         check_duplicates = menu.addAction("Check for duplicate IDs")
         check_duplicates.setVisible(isinstance(node, mpm.canmodel.MultiplexedMessage))
 
@@ -685,6 +692,12 @@ class Window:
                 node.update()
             elif action is optimize:
                 node.optimize_multiplexer_ids()
+            elif action is copyname:
+                if hasattr(node, "name"):
+                    QApplication.clipboard().setText(str(node.name))
+            elif action is copyuuid:
+                if hasattr(node, "uuid"):
+                    QApplication.clipboard().setText(str(node.uuid))
             elif action is check_duplicates:
                 duplicates = node.check_duplicate_ids()
                 if len(duplicates) == 0:

--- a/src/mpm/staticmodbusmodel.py
+++ b/src/mpm/staticmodbusmodel.py
@@ -1003,8 +1003,11 @@ def root_child_from(self, node) -> typing.Union[FunctionData, list]:
                 ),
             )
 
-            # Append to output if on correct access level
-            if access_level == access_levels.by_name("Service_Tech").uuid:
+            # Append to output if on correct access level and signal is not empty
+            if (
+                access_level == access_levels.by_name("Service_Tech").uuid
+                and signal.bits > 0
+            ):
                 output.append(
                     FunctionData(
                         parameter_uuid=signal.parameter_uuid,

--- a/src/mpm/staticmodbusmodel.py
+++ b/src/mpm/staticmodbusmodel.py
@@ -456,7 +456,6 @@ class FunctionDataBitfield(epyqlib.treenode.TreeNode):
             node,
             (
                 FunctionDataBitfieldMember,
-                epyqlib.pm.parametermodel.Parameter,
                 mpm.canmodel.Signal,
                 mpm.canmodel.Multiplexer,
                 mpm.canmodel.Message,
@@ -471,10 +470,7 @@ class FunctionDataBitfield(epyqlib.treenode.TreeNode):
         return True
 
     def child_from(self, node):
-        if isinstance(node, epyqlib.pm.parametermodel.Parameter):
-            self.parameter_uuid = node.uuid
-            return None
-        elif isinstance(
+        if isinstance(
             node,
             (
                 mpm.canmodel.Multiplexer,
@@ -934,7 +930,6 @@ def root_can_drop_on(self, node) -> bool:
     return isinstance(
         node,
         (
-            epyqlib.pm.parametermodel.Parameter,
             mpm.canmodel.Signal,
             mpm.canmodel.Multiplexer,
             mpm.canmodel.CanTable,


### PR DESCRIPTION
## Jira Story
[SC-2603](https://epcpower.atlassian.net/browse/SC-2603)

## About
- Select only `Service Tech` access level parameters when generating static modbus from CAN data. Needed since static modbus will only contain parameters with this access level.
- Also filter out empty CAN signals
- Context menu command to copy object name or UUID

## Associated Pull Requests

* [ ] _
* [ ] _

## Reproduction Steps

## Validation


[SC-2603]: https://epcpower.atlassian.net/browse/SC-2603?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ