### PR TITLE
feat(SC-2749): Format anomaly table to look the same as CAN parameter…

### DIFF
--- a/src/mpm/anomaliestoxlsx.py
+++ b/src/mpm/anomaliestoxlsx.py
@@ -9,9 +9,11 @@ import epyqlib.utils.general
 import mpm.c
 import mpm.mpm_helper
 import mpm.anomalymodel
+import mpm.cantoxlsx
 
 builders = epyqlib.utils.general.TypeMap()
 
+MAX_COLUMN_WIDTH = 20
 
 @attr.s
 class Fields(mpm.mpm_helper.FieldsInterface):
@@ -104,10 +106,6 @@ class Root:
     trigger_types = attr.ib()
     skip_output = attr.ib(default=False)
 
-    header_font = openpyxl.styles.Font(bold=True)
-    header_fill = openpyxl.styles.PatternFill(
-        start_color="FF8DB4E2", end_color="FF8DB4E2", fill_type="solid"
-    )
     table_alignment = openpyxl.styles.Alignment(
         horizontal="left", vertical="top", wrapText=True
     )
@@ -118,6 +116,7 @@ class Root:
             return None
 
         workbook = openpyxl.Workbook()
+        assert workbook.active != None
         workbook.remove(workbook.active)
 
         # Add sheet for response level descriptions
@@ -156,30 +155,40 @@ class Root:
         # Add and format header row
         worksheet.append(field_names.as_filtered_tuple(self.column_filter))
         for cell in worksheet[1]:
-            cell.font = self.header_font
-            cell.fill = self.header_fill
+            cell.font = mpm.cantoxlsx.CELL_FONT
+            cell.fill = mpm.cantoxlsx.CELL_FILL_GROUP
+            cell.border = mpm.cantoxlsx.CELL_BORDER
+            cell.alignment = self.table_alignment
 
         # Iterate anomaly tables and add new rows from them
+        rows = []
         for anomaly_table in self.wrapped.children:
 
-            rows = builders.wrap(
+            rows += builders.wrap(
                 wrapped=anomaly_table,
                 parameter_uuid_finder=self.parameter_uuid_finder,
             ).gen()
 
-            for row in rows:
-                worksheet.append(
-                    row.as_filtered_tuple(self.column_filter),
-                )
+        # Sort anomalies by code
+        rows.sort(key=lambda x: x.code)
 
-        # Apply text alignment to table
+        # Add the worksheet rows
+        for row in rows:
+            worksheet.append(
+                row.as_filtered_tuple(self.column_filter),
+            )
+
+        # Apply formatting to table
         for row in worksheet.iter_rows(min_row=2):
             for cell in row:
+                cell.font = mpm.cantoxlsx.CELL_FONT
+                cell.border = mpm.cantoxlsx.CELL_BORDER
                 cell.alignment = self.table_alignment
 
         # Adjust column widths in the worksheet in regards of text length
         for column_cells in worksheet.columns:
             length = max(len(as_text(cell.value)) for cell in column_cells)
+            length = min(length, MAX_COLUMN_WIDTH)
             worksheet.column_dimensions[column_cells[0].column_letter].width = length + 5
 
     def generate_enum_info_sheet(
@@ -204,8 +213,9 @@ class Root:
             info_sheet_field_names.as_filtered_tuple(self.column_filter),
         )
         for cell in worksheet[1]:
-            cell.font = self.header_font
-            cell.fill = self.header_fill
+            cell.font = mpm.cantoxlsx.CELL_FONT
+            cell.fill = mpm.cantoxlsx.CELL_FILL_GROUP
+            cell.border = mpm.cantoxlsx.CELL_BORDER
 
         # Add response level descriptions
         row = InfoSheetFields()
@@ -222,6 +232,8 @@ class Root:
                 cell.alignment = openpyxl.styles.Alignment(
                     wrap_text=True, horizontal="left", vertical="top"
                 )
+                cell.font = mpm.cantoxlsx.CELL_FONT
+                cell.border = mpm.cantoxlsx.CELL_BORDER
 
         # Format column widths
         worksheet.column_dimensions["A"].width = 50

--- a/src/mpm/canmodel.py
+++ b/src/mpm/canmodel.py
@@ -595,19 +595,16 @@ class MultiplexedMessage(epyqlib.treenode.TreeNode):
 
     def sort_multiplexer_ids(self) -> None:
         """
-        Sort children by multiplexer ID
+        Sort children by multiplexer ID. This does not update the tree
+        view so the GUI has to be relaunched to display parameters
+        in new order.
 
         Args:
             self: self-instance of this MultiplexedMessage.
         Returns:
             None
         """
-        children_copy = self.children.copy()
-        children_copy.sort(key=lambda x: node_multiplexer_id(x))
-        # Re-add children to trigger the tree update
-        self.recursively_remove_children()
-        for child in children_copy:
-            self.append_child(child)
+        self.children.sort(key=lambda x: node_multiplexer_id(x))
 
     def optimize_multiplexer_ids(self) -> None:
         """


### PR DESCRIPTION
## Jira Story
https://epcpower.atlassian.net/browse/SC-2749

## About
Use same formatting in the anomaly table as in CAN parameter table. 
![image](https://github.com/user-attachments/assets/8017cb85-6332-475b-a15f-5b677066eb45)
In the manual I was planning to leave out "trigger type" & "detail" columns to be able to fit it.
![image](https://github.com/user-attachments/assets/e25f51b7-5cf1-41fa-81e6-69e9e4ae66f2)


## Associated Pull Requests

* [ ] _
* [ ] _

## Reproduction Steps

## Validation
